### PR TITLE
Added a proposal feature to solve the problem of displaying wrong hit count

### DIFF
--- a/airone/lib/elasticsearch.py
+++ b/airone/lib/elasticsearch.py
@@ -726,6 +726,8 @@ def make_search_results(res, hint_attrs, limit, hint_referral):
     for (entry, hit_attrs) in sorted(hit_infos.items(), key=lambda x: x[0].name):
         # ignore an entry doesn't match hint attrs
         if not _is_matched_entry(hit_attrs, hint_attrs):
+            # subtract number from hitted count because it will be ignored
+            results['ret_count'] -= 1
             continue
 
         ret_info = {


### PR DESCRIPTION
This is a solution to subtract hit count from the elasticsearch results when user specified special characters (`^` or `$`).

(I need test to confirm the 'ret_count' that returns make_search_results will be expected when the parameter "hint_attrs" contains the special characters (`^` or `$`) and matches prepared entries).

And this doesn't break existing behavior on make_search_results() which is mentioned in the following comment.
https://github.com/dmm-com/airone/pull/97#issuecomment-817114474
<img width="630" alt="スクリーンショット 2021-04-29 15 26 01" src="https://user-images.githubusercontent.com/469934/116510759-62f13080-a900-11eb-91d8-d580550972ab.png">
